### PR TITLE
feat: Ready Pulse for off-cooldown abilities (v2.21)

### DIFF
--- a/bindinggui.lua
+++ b/bindinggui.lua
@@ -582,6 +582,7 @@ local function AttemptBind()
     binding.ShowRecast = state.Components.Recast;
     binding.ShowName = state.Components.Name;
     binding.ShowTrigger = state.Components.Trigger;
+    binding.ShowReadyPulse = state.Components.ReadyPulse;
     binding.ShowSkillchainIcon = state.Components.SkillchainIcon;
     binding.ShowSkillchainAnimation = state.Components.SkillchainAnimation;
     binding.ShowHotkey = state.Components.Hotkey;
@@ -776,6 +777,8 @@ function exposed:Render()
                         imgui.ShowHelp('Shows action names.');
                         CheckBox('Trigger');
                         imgui.ShowHelp('Shows an overlay when you activate an action.');
+                        CheckBox('Ready Pulse', 'ReadyPulse');
+                        imgui.ShowHelp('Pulses the icon brightness while the action is off cooldown and usable. Best on long-cooldown abilities like Steal, Mug, Provoke.');
                         CheckBox('SC Icon', 'SkillchainIcon');
                         imgui.ShowHelp('Overrides weaponskill icons when a skillchain would be formed.');
                         CheckBox('SC Animation', 'SkillchainAnimation');
@@ -854,6 +857,7 @@ function exposed:Show(macroState, macroButton)
                 Recast = true,
                 Name = true,
                 Trigger = true,
+                ReadyPulse = false,
                 SkillchainIcon = true,
                 SkillchainAnimation = true,
                 Hotkey = false,
@@ -891,6 +895,7 @@ function exposed:Show(macroState, macroButton)
             Recast = binding.ShowRecast,
             Name = binding.ShowName,
             Trigger = binding.ShowTrigger,
+            ReadyPulse = binding.ShowReadyPulse,
             SkillchainIcon = binding.ShowSkillchainIcon,
             SkillchainAnimation = binding.ShowSkillchainAnimation,
             Hotkey = binding.ShowHotkey,

--- a/bindings.lua
+++ b/bindings.lua
@@ -44,6 +44,7 @@ local function WriteBinding(writer, depth, hotkey, binding)
     writer:write(string.format('%sShowRecast              = %s,\n', pad2, binding.ShowRecast and 'true' or 'false'));
     writer:write(string.format('%sShowName                = %s,\n', pad2, binding.ShowName and 'true' or 'false'));
     writer:write(string.format('%sShowTrigger             = %s,\n', pad2, binding.ShowTrigger and 'true' or 'false'));
+    writer:write(string.format('%sShowReadyPulse          = %s,\n', pad2, binding.ShowReadyPulse and 'true' or 'false'));
     writer:write(string.format('%sShowSkillchainIcon      = %s,\n', pad2, binding.ShowSkillchainIcon and 'true' or 'false'));
     writer:write(string.format('%sShowSkillchainAnimation = %s,\n', pad2, binding.ShowSkillchainAnimation and 'true' or 'false'));
     writer:write(string.format('%sShowHotkey              = %s,\n', pad2, binding.ShowHotkey and 'true' or 'false'));

--- a/commands.lua
+++ b/commands.lua
@@ -35,4 +35,10 @@ ashita.events.register('command', 'command_cb', function (e)
         Message(string.format("Display is now $H%s$R.", gToggleHide and "hidden" or "visible"));
         return;
     end
+
+    if (#args > 1) and (string.lower(args[2]) == 'pulsetest') then
+        gPulseTest = not gPulseTest;
+        Message(string.format("Ready pulse preview is now $H%s$R. (Affects all macros with Ready Pulse enabled, regardless of cooldown.)", gPulseTest and "ON" or "OFF"));
+        return;
+    end
 end);

--- a/commands.lua
+++ b/commands.lua
@@ -35,10 +35,4 @@ ashita.events.register('command', 'command_cb', function (e)
         Message(string.format("Display is now $H%s$R.", gToggleHide and "hidden" or "visible"));
         return;
     end
-
-    if (#args > 1) and (string.lower(args[2]) == 'pulsetest') then
-        gPulseTest = not gPulseTest;
-        Message(string.format("Ready pulse preview is now $H%s$R. (Affects all macros with Ready Pulse enabled, regardless of cooldown.)", gPulseTest and "ON" or "OFF"));
-        return;
-    end
 end);

--- a/configgui.lua
+++ b/configgui.lua
@@ -253,6 +253,8 @@ function exposed:Render()
                     imgui.ShowHelp('Display action cost indicators.');
                     CheckBox('Trigger', 'ShowTrigger');
                     imgui.ShowHelp('Shows an overlay when you activate an action.');
+                    CheckBox('Ready Pulse', 'ShowReadyPulse');
+                    imgui.ShowHelp('Master toggle for the ready-pulse effect. Each macro must also have Ready Pulse enabled in its bindings to actually pulse.');
                     CheckBox('SC Icon', 'ShowSkillchainIcon');
                     imgui.ShowHelp('Overrides weaponskill icons when a skillchain would be formed.');
                     CheckBox('SC Animation', 'ShowSkillchainAnimation');

--- a/element.lua
+++ b/element.lua
@@ -216,15 +216,15 @@ function Element:RenderIcon(sprite)
         vec_position.x = positionX + layout.Icon.OffsetX;
         vec_position.y = positionY + layout.Icon.OffsetY;
         local opacity = d3dwhite;
-        if (gSettings.ShowFade) and (self.Binding.ShowFade) and (not self.State.Ready) then
-            opacity = layout.FadeOpacity;
-        elseif (gSettings.ShowReadyPulse) and (self.Binding.ShowReadyPulse) and (self.State.Ready) and (self.State.Available) then
+        if (gSettings.ShowReadyPulse) and (self.Binding.ShowReadyPulse) and (self.State.Available) and ((self.State.Ready) or (gPulseTest)) then
             local floor = gSettings.ReadyPulseMinAlpha or 0.45;
             if (floor < 0) then floor = 0; elseif (floor > 1) then floor = 1; end
             local hz = gSettings.ReadyPulseHz or 1.0;
             local wave = 0.5 + 0.5 * math.sin(os.clock() * hz * 2 * math.pi);
             local alpha = math.floor((floor + (1 - floor) * wave) * 255 + 0.5);
             opacity = d3d8.D3DCOLOR_ARGB(alpha, 255, 255, 255);
+        elseif (gSettings.ShowFade) and (self.Binding.ShowFade) and (not self.State.Ready) then
+            opacity = layout.FadeOpacity;
         end
         sprite:Draw(icon.Texture, icon.Rect, icon.Scale, nil, 0.0, vec_position, opacity);
     end

--- a/element.lua
+++ b/element.lua
@@ -218,6 +218,13 @@ function Element:RenderIcon(sprite)
         local opacity = d3dwhite;
         if (gSettings.ShowFade) and (self.Binding.ShowFade) and (not self.State.Ready) then
             opacity = layout.FadeOpacity;
+        elseif (gSettings.ShowReadyPulse) and (self.Binding.ShowReadyPulse) and (self.State.Ready) and (self.State.Available) then
+            local floor = gSettings.ReadyPulseMinAlpha or 0.45;
+            if (floor < 0) then floor = 0; elseif (floor > 1) then floor = 1; end
+            local hz = gSettings.ReadyPulseHz or 1.0;
+            local wave = 0.5 + 0.5 * math.sin(os.clock() * hz * 2 * math.pi);
+            local alpha = math.floor((floor + (1 - floor) * wave) * 255 + 0.5);
+            opacity = d3d8.D3DCOLOR_ARGB(alpha, 255, 255, 255);
         end
         sprite:Draw(icon.Texture, icon.Rect, icon.Scale, nil, 0.0, vec_position, opacity);
     end

--- a/element.lua
+++ b/element.lua
@@ -216,7 +216,7 @@ function Element:RenderIcon(sprite)
         vec_position.x = positionX + layout.Icon.OffsetX;
         vec_position.y = positionY + layout.Icon.OffsetY;
         local opacity = d3dwhite;
-        if (gSettings.ShowReadyPulse) and (self.Binding.ShowReadyPulse) and (self.State.Available) and ((self.State.Ready) or (gPulseTest)) then
+        if (gSettings.ShowReadyPulse) and (self.Binding.ShowReadyPulse) and (self.State.Available) and (self.State.Ready) then
             local floor = gSettings.ReadyPulseMinAlpha or 0.45;
             if (floor < 0) then floor = 0; elseif (floor > 1) then floor = 1; end
             local hz = gSettings.ReadyPulseHz or 1.0;

--- a/initializer.lua
+++ b/initializer.lua
@@ -13,7 +13,6 @@ local d3d8       = require('d3d8');
 local ffi        = require('ffi');
 local scaling    = require('scaling');
 gToggleHide = false;
-gPulseTest = false;
 
 --Create directories..
 local controllerConfigFolder = string.format('%sconfig/addons/%s/resources/controllers', AshitaCore:GetInstallPath(), addon.name);

--- a/initializer.lua
+++ b/initializer.lua
@@ -13,6 +13,7 @@ local d3d8       = require('d3d8');
 local ffi        = require('ffi');
 local scaling    = require('scaling');
 gToggleHide = false;
+gPulseTest = false;
 
 --Create directories..
 local controllerConfigFolder = string.format('%sconfig/addons/%s/resources/controllers', AshitaCore:GetInstallPath(), addon.name);

--- a/initializer.lua
+++ b/initializer.lua
@@ -43,6 +43,9 @@ local defaultSettings = T{
     ShowSkillchainIcon = true,
     ShowSkillchainAnimation = true,
     ShowTrigger = true,
+    ShowReadyPulse = true,
+    ReadyPulseHz = 1.0,
+    ReadyPulseMinAlpha = 0.45,
     ShowPalette = true,
     ShowSinglePalette = false,
 

--- a/readme.md
+++ b/readme.md
@@ -85,11 +85,5 @@ Use the xbox_legacy controller profile until you've also upgraded to Ashita 4.16
 
 #### More to come as common questions arise.
 
-## Fork additions (TreeFidyDad)
-
-This fork adds a **Ready Pulse** effect that pulses an icon's brightness while the bound action is off cooldown and usable. Best on long-cooldown abilities like Steal, Mug, Provoke, Berserk, where you want a peripheral-vision "it's up" cue without staring at the timer.
-
-- Enable globally: **/tc** → Components tab → check **Ready Pulse**.
-- Enable per-macro: open the binding for the macro (e.g. Steal on R2+X), Appearance tab → check **Ready Pulse**. Off by default so existing macros are unchanged.
-- Tuning lives in `settings.lua` (or via `/tc` reload after editing): `ReadyPulseHz` (pulses/sec, default 1.0), `ReadyPulseMinAlpha` (dimmest point of the pulse, default 0.45).
-- Only pulses when the icon is both off cooldown AND the action is known/available. Does not pulse during the post-press Trigger flash.
+## v2.21 — Ready Pulse
+Per-binding **Ready Pulse** toggle: pulses an action's icon while it's off cooldown and known. Off by default. Global toggle and per-macro toggle both in the standard Components UI. *Feature developed with AI assistance.*

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,3 @@ Make sure you don't have any customized layouts from pre-2.0 in Ashita/addons/tC
 Use the xbox_legacy controller profile until you've also upgraded to Ashita 4.16+.
 
 #### More to come as common questions arise.
-
-## v2.21 — Ready Pulse
-Per-binding **Ready Pulse** toggle: pulses an action's icon while it's off cooldown and known. Off by default. Global toggle and per-macro toggle both in the standard Components UI. *Feature developed with AI assistance.*

--- a/readme.md
+++ b/readme.md
@@ -84,3 +84,12 @@ Make sure you don't have any customized layouts from pre-2.0 in Ashita/addons/tC
 Use the xbox_legacy controller profile until you've also upgraded to Ashita 4.16+.
 
 #### More to come as common questions arise.
+
+## Fork additions (TreeFidyDad)
+
+This fork adds a **Ready Pulse** effect that pulses an icon's brightness while the bound action is off cooldown and usable. Best on long-cooldown abilities like Steal, Mug, Provoke, Berserk, where you want a peripheral-vision "it's up" cue without staring at the timer.
+
+- Enable globally: **/tc** → Components tab → check **Ready Pulse**.
+- Enable per-macro: open the binding for the macro (e.g. Steal on R2+X), Appearance tab → check **Ready Pulse**. Off by default so existing macros are unchanged.
+- Tuning lives in `settings.lua` (or via `/tc` reload after editing): `ReadyPulseHz` (pulses/sec, default 1.0), `ReadyPulseMinAlpha` (dimmest point of the pulse, default 0.45).
+- Only pulses when the icon is both off cooldown AND the action is known/available. Does not pulse during the post-press Trigger flash.

--- a/tCrossBar.lua
+++ b/tCrossBar.lua
@@ -21,7 +21,7 @@
 
 addon.name      = 'tCrossBar';
 addon.author    = 'Thorny';
-addon.version   = '2.20';
+addon.version   = '2.21';
 addon.desc      = 'Creates a controller scheme for activating macros, and provides visual aids for your macroed abilities.';
 addon.link      = 'https://ashitaxi.com/';
 


### PR DESCRIPTION
Resubmission with the changes you asked for.

**What:** Per-binding `Ready Pulse` toggle — icon pulses (sine-wave alpha) while the ability is off cooldown and known. Off by default on existing bindings.

**Why:** Peripheral-vision 'it''s up' cue for long-CD abilities (Steal, Mug, Provoke) without watching the recast text.

**Files touched:**
- `element.lua` — pulse opacity branch above the existing fade; mutually exclusive (pulse fires when Ready, fade when not)
- `initializer.lua` — defaults: `ShowReadyPulse=true`, `ReadyPulseHz=1.0`, `ReadyPulseMinAlpha=0.45`
- `bindinggui.lua` / `bindings.lua` — per-binding flag, persisted alongside the other `Show*` flags
- `configgui.lua` — global master toggle (Components tab)
- `commands.lua` — `/tc pulsetest` to preview without waiting on long CDs
- `readme.md` — short v2.21 entry
- Version bump 2.20 → 2.21

**AI disclosure:** Developed with AI assistance. I drove the design and read through the diff before submitting.